### PR TITLE
Bug Fix for flutter fragment activity

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/android/src/main/kotlin/billion/group/wireguard_flutter/WireguardFlutterPlugin.kt
+++ b/android/src/main/kotlin/billion/group/wireguard_flutter/WireguardFlutterPlugin.kt
@@ -10,7 +10,6 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.PluginRegistry
 
 import android.app.Activity
-import io.flutter.embedding.android.FlutterActivity
 import android.content.Intent
 import android.content.Context
 import android.net.ConnectivityManager
@@ -65,7 +64,7 @@ class WireguardFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     }
 
     override fun onAttachedToActivity(activityPluginBinding: ActivityPluginBinding) {
-        this.activity = activityPluginBinding.activity as FlutterActivity
+        this.activity = activityPluginBinding.activity
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
@@ -73,7 +72,7 @@ class WireguardFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     }
 
     override fun onReattachedToActivityForConfigChanges(activityPluginBinding: ActivityPluginBinding) {
-        this.activity = activityPluginBinding.activity as FlutterActivity
+        this.activity = activityPluginBinding.activity
     }
 
     override fun onDetachedFromActivity() {

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 07 13:06:09 CEST 2023
+#Sun Jun 01 19:30:16 BDT 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
### Fix Bug
When i user FlutterFragmentActivity then show me error. basically it happened for type casting by FlutterActivity . to solve this problem i just remove the hard type cast . then it also work for FlutterFragmentActivity

Error:

E/AndroidRuntime(25491): FATAL EXCEPTION: DefaultDispatcher-worker-1
E/AndroidRuntime(25491): Process: com.beevpn.androidvpn, PID: 25491
E/AndroidRuntime(25491): java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.PackageManager android.content.Context.getPackageManager()' on a null object reference
E/AndroidRuntime(25491): at android.net.VpnService.isKGClientPackageInstalled(VpnService.java:243)
E/AndroidRuntime(25491): at android.net.VpnService.prepare(VpnService.java:281)
E/AndroidRuntime(25491): at billion.group.wireguard_flutter.WireguardFlutterPlugin.checkPermission(WireguardFlutterPlugin.kt:275)
E/AndroidRuntime(25491): at billion.group.wireguard_flutter.WireguardFlutterPlugin.access$checkPermission(WireguardFlutterPlugin.kt:39)
E/AndroidRuntime(25491): at